### PR TITLE
Fix typos across blog posts

### DIFF
--- a/_posts/2018-01-07-wordpress-plugin-and-theme-development-using-git-only.md
+++ b/_posts/2018-01-07-wordpress-plugin-and-theme-development-using-git-only.md
@@ -23,7 +23,7 @@ Start with creating 'dummy' `.travis.yml` file in your repository to tell Travis
 
 {% gist 112d65c7998be8d3644c641b247abafb %}
 
-Travis will procceed all future commits and pull requests for repository with `.travis.yml` file.
+Travis will proceed all future commits and pull requests for the repository with `.travis.yml` file.
 
 ## Step 2: Configure WordPress Plugin Assets
 
@@ -50,7 +50,7 @@ Actually you don't need to execute script to deploy a new release. Travis will d
 
 I think you don't need to deploy each new commit, you need to tell Travis to execute deployment script only on "some" specific events.  
 
-> I'd prefer using tags to specify plugin releases. I want Travis to submit new plugin version to Wordpress each time I push a new git tag.
+> I'd prefer using tags to specify plugin releases. I want Travis to submit a new plugin version to WordPress each time I push a new git tag.
 
 To enable deployment on git tags provide next configuration to `.travis.yml`:
 
@@ -71,7 +71,7 @@ To enable deployment on git tags provide next configuration to `.travis.yml`:
 
 ## Conclusion
 
-*Now you have complete setup of automated plugin deployment proccess.*
+*Now you have a complete setup for an automated plugin deployment process.*
 
 *With this way you don't need to do any SVN specific actions. You may just develop plugins and when you're ready to give users a new version just push tag for commit you want to deploy. Travis will do all required stuff and after a few minutes you'll see new deployed version on WordPress website.*
 

--- a/_posts/2018-03-14-how-to-deploy-applications-to-digitalocean-with-terraform.md
+++ b/_posts/2018-03-14-how-to-deploy-applications-to-digitalocean-with-terraform.md
@@ -12,7 +12,7 @@ comments: true
 
 > I like [DigitalOcean](https://m.do.co/c/fac05d89f2e5) as a cloud servers provider because it is pretty simple and doesn't cost too much. It already has complete enough infrastructure things for small websites and large services.  
 
-*DigitalOcean has clean user-friendly Control Panel UI to manage droplets, networks and so on. I used to configure applications manualy, but there is a way to do it much faster and more reliable.*
+*DigitalOcean has a clean user-friendly Control Panel UI to manage droplets, networks and so on. I used to configure applications manually, but there is a way to do it much faster and more reliably.*
 
 *[Terraform](https://www.terraform.io) is a tool which allows to define any kind of infrastructure as a simple text document and deploy or update it with a single command.*
 
@@ -42,7 +42,7 @@ Begin with creating directory to store Terraform configuration files. Then creat
 
 {% gist 5888fa06e5b8fc8afab15e44c95c13e1 %}
 
-Domain `ip_address` uses reference to defined droplet as a value to authomatically map droplet to domain.
+Domain `ip_address` uses a reference to the defined droplet as a value to automatically map the droplet to the domain.
 
 *Terraform is smart enough to understand that domain can't be created without droplet's IP address, so first it will create a droplet, and then it will give correct ip_address for the domain value.*
 
@@ -50,7 +50,7 @@ Almost done. The last thing to do is to set provider credentials, so create `cre
 
 {% gist 874254f5ff8616f7dd7679b443012b79 %}
 
-*You need to generate DititalOcean API token at the [API](https://cloud.digitalocean.com/settings/api/tokens) section of [DigitalOcean Control Panel](https://cloud.digitalocean.com)*
+*You need to generate a DigitalOcean API token in the [API](https://cloud.digitalocean.com/settings/api/tokens) section of the [DigitalOcean Control Panel](https://cloud.digitalocean.com)*
 
 ##### Here we go...
 
@@ -81,7 +81,7 @@ Terraform variable looks the next way:
 
 #### Export Variables
 
-Create `variables.tf` file and think about which arguments **may be changed** and which arguments **should be changed** in similiar deployments (applications).
+Create a `variables.tf` file and think about which arguments **may be changed** and which arguments **should be changed** in similar deployments (applications).
 
 For example, **droplet size** and **image** can be the same for different projects, so you can provide default value for this arguments, but **domain name** can't be the same for different projects, so you just need to define that you're requiring this argument but it won't have default value.
 

--- a/_posts/2018-05-21-facebook-enforces-https---developers-thoughts.md
+++ b/_posts/2018-05-21-facebook-enforces-https---developers-thoughts.md
@@ -11,18 +11,18 @@ image:
 
 > This blog post is a cry from the heart. I don't know why, but there are more and more people who don't even try to think before doing anything.
 
-Sometime ago Facebook introduced new requirements for API applications. They want you to use only HTTPS as a transfer protocol to protect sensitive data from in-secure trasfer. I'm happy about it, but as usual they half-assed it.
+Some time ago Facebook introduced new requirements for API applications. They want you to use only HTTPS as a transfer protocol to protect sensitive data from insecure transfer. I'm happy about it, but as usual they half-assed it.
 
-Most of applications I have developed are deployed to AWS or almost the same providers and use next infrastructure schema:
+Most of the applications I have developed are deployed to AWS or similar providers and use the following infrastructure scheme:
 
 [![Application Infrastructure](/images/application-architecture.png)](/images/application-architecture.png)
 
-So, I handle secured connection with Load Balancer and the application doesn't even know about existing of https connection. It just works.  
-But locally developers don't have Load Balancer and it's okay to communicate with the application by HTTP protocol locally.
+So, I handle the secure connection with a load balancer and the application doesn't even know about the existence of the HTTPS connection. It just works.
+But locally developers don't have a load balancer and it's okay to communicate with the application over HTTP.
 
-Facebook enforces HTTPS for applications and doesn't allow to turn it off even if the application isn't published for users. Okay, there is another option: Facebook gives ability to make some kind of 'test' version of existing application with different API keys and secrets. But even in test application you still enforced to use HTTPS. So you can't check Facebook login without HTTPS enabled. What the heck are you Facebook doing?
+Facebook enforces HTTPS for applications and doesn't allow it to be turned off even if the application isn't published for users. Okay, there is another option: Facebook gives the ability to make a kind of 'test' version of an existing application with different API keys and secrets. But even in a test application you are still forced to use HTTPS. So you can't check Facebook login without HTTPS enabled. What the heck are you doing, Facebook?
 
-I know that I can make self-signed certificate or use free certificate by [Let's Encrypt](https://letsencrypt.org/) but why should I mess with it if I can resolve it on infrastructure layer? With this enforcement developers need to "implement" local "secured" environment. Seriously?
+I know that I can make a self-signed certificate or use a free certificate from [Let's Encrypt](https://letsencrypt.org/), but why should I mess with it if I can resolve it on the infrastructure layer? With this enforcement developers need to "implement" a local "secure" environment. Seriously?
 
 <h3 style="text-align:center">🔥 Facebook burn in Hell! 🔥</h3>
 

--- a/_posts/2019-01-29-terraform-module-example.md
+++ b/_posts/2019-01-29-terraform-module-example.md
@@ -62,9 +62,9 @@ The latest thing is to use created `template_file` as a droplet's user_data.
 
 ## Distribution
 
-> I prefer use GitHub to store and distribute modules.
+> I prefer to use GitHub to store and distribute modules.
 
-You need to create GitHub repository and just put all files into it. 
+You need to create a GitHub repository and just put all files into it.
 
 Check out [**the repo**](https://github.com/sergeykuzmich/tfmodule-do_wordpress) with this configuration.
 
@@ -80,14 +80,14 @@ That's it! You just need to provide valid credentials to perform this action.
 
 #### Credentials
 
-I use the next way to provide credentials for terraform:
+I use the following way to provide credentials for Terraform:
 
-1. the file with actual credentials as a environment varialbes (somewhere in user's home directory):
+1. a file with the actual credentials as environment variables (somewhere in the user's home directory):
     `export DIGITALOCEAN_TOKEN=8d50ac...059828b`
-2. .env file in terraform configuration directory to wrap environment variables into Terraform way:
+2. a `.env` file in the Terraform configuration directory to wrap environment variables in a Terraform-friendly way:
     `export TF_VAR_token=$DIGITALOCEAN_TOKEN`
 
-DigitalOcean provider requires `token` arugment as a access_key, so I wrap `$DIGITALOCEAN_TOKEN` into `$TF_VAR_token=$DIGITALOCEAN_TOKEN`.
+The DigitalOcean provider requires the `token` argument as an access_key, so I wrap `$DIGITALOCEAN_TOKEN` into `$TF_VAR_token=$DIGITALOCEAN_TOKEN`.
 
 Now, to apply any changes I just `source ~/do_credentials` file (the first one) and run Terraform commands.
 

--- a/_posts/2019-04-07-git-ignore-on-commit.md
+++ b/_posts/2019-04-07-git-ignore-on-commit.md
@@ -10,25 +10,25 @@ image:
 comments: true
 ---
 
-I used SVN & Tortoise SVN for years ago. There was one cool feature: **ignore-on-commit**.
+I used SVN & Tortoise SVN years ago. There was one cool feature: **ignore-on-commit**.
 
-Now I use Git to track projects & file changes. I'm pretty sure that Tortoise GIT has **ignore-on-commit** feature, but I prefer to use Git within Terminal. Anyway there is a legal way to do the same behavior.
+Now I use Git to track projects and file changes. I'm pretty sure that Tortoise GIT has an **ignore-on-commit** feature, but I prefer to use Git within the terminal. Anyway, there is a straightforward way to achieve the same behavior.
 
-* `git update-index --assume-unchaged <filename>`  
+* `git update-index --assume-unchanged <filename>`
     makes file changes 'invisible' for git tree status;
-* `git update-index --no-assume-unchaged <filename>`  
-    unhides file from beeing 'invisible' for git;
+* `git update-index --no-assume-unchanged <filename>`
+    unhides file from being 'invisible' for git;
 * `git ls-files -v | grep '^h' | cut -c3-`  
     shows all 'invisible' files;
 
 There is one more tip with it - use aliases. Put lines below to .gitconfig file.
 {% gist 8a110a1bbfcf43a985597400336c28e8 %}
 
-Now commands at the begining is available the next way:
+Now the commands at the beginning are available the following way:
 * `git hide <filename>`  
     makes file changes 'invisible' for git tree status;
-* `git unhide <filename>`  
-    unhides file from beeing 'invisible' for git;
+* `git unhide <filename>`
+    unhides file from being 'invisible' for git;
 * `git show-hidden`  
     shows all 'invisible' files;
 

--- a/_posts/2021-04-26-wordpress-configuration-cheat-sheet.md
+++ b/_posts/2021-04-26-wordpress-configuration-cheat-sheet.md
@@ -10,7 +10,7 @@ image:
 comments: true
 ---
 
-> Original post was located by https://blog.ripstech.com/2018/wordpress-configuration-cheat-sheet/ url.
+> Original post was located at https://blog.ripstech.com/2018/wordpress-configuration-cheat-sheet/.
 
 WordPress is the most frequently installed web application in the world. The system is operated not only by experienced developers but also by beginners. This post summarizes what to look out for when configuring your WordPress installation’s security.
 
@@ -40,7 +40,7 @@ The salts and keys are important for different functionalities in a WordPress ap
 
 ## 4. Use SSL Encryption
 
-No one should be able to read the traffic between you server and your users. Use SSL encryption and force WordPress to use only this type of connection.
+No one should be able to read the traffic between your server and your users. Use SSL encryption and force WordPress to use only this type of connection.
 
 It is now standard practice to encrypt your traffic. Many browser manufacturers mark un-encrypted connections as dangerous. Often web hosters offer their customers simple free certificates to enable SSL encryption. Also providers like Let’s Encrypt offer free certificates.
 

--- a/_posts/2022-11-27-cursor-based-pagination.markdown
+++ b/_posts/2022-11-27-cursor-based-pagination.markdown
@@ -10,13 +10,13 @@ image:
 comments: true
 ---
 
-A lot of articles & notes are written about disadvantages of "regular" pages in browsing lists of content. The major disadvantages is speed of sql `OFFSET` & duplicates of "edge" elements.
+Many articles and notes have been written about the disadvantages of "regular" pages when browsing lists of content. The major disadvantages are the speed of SQL `OFFSET` and duplicates of "edge" elements.
 
-The next generation of dynamicly changing content (blog feeds, twits, instagram posts) requires advanced content navigation approaches. So the one of them is cursor-based pagination.
+The next generation of dynamically changing content (blog feeds, tweets, Instagram posts) requires advanced content navigation approaches. One of them is cursor-based pagination.
 
-The idea of cursor-based pagination is moving between "next" & "previous" pages fast, without duplicates & missed content. Usually users don't have "pages" navigation, it looks like infinite scroll on the feed page. The examples of this type navigation is infinite feeds of twitter, instagram, facebook, etc.
+The idea of cursor-based pagination is moving between "next" and "previous" pages quickly, without duplicates or missing content. Usually users don't have "pages" navigation—it looks like infinite scroll on the feed page. Examples of this type of navigation are the infinite feeds of Twitter, Instagram, Facebook, etc.
 
-The developers who integrates with this type of pagination also doesn't have "pages" in API, but has a "cursor" to the next or previous page. It looks like:
+Developers who integrate with this type of pagination also don't have "pages" in the API but have a "cursor" to the next or previous page. It looks like:
 
 {% gist 60ba05b97448c9595434cb35ea4afb84 %}
 
@@ -27,13 +27,13 @@ The minimal model of any content is:
 * **DATA** – a field, or number of fields of "human" content;
 * **ORDER** – a field, or number of fields to determine the order content should be displayed in;
 
-> The modern platforms uses algorythms to determine the order of the content for each user, this type is out-of-scope of this article.
+> Modern platforms use algorithms to determine the order of the content for each user; this approach is out of scope for this article.
 
-Since the **ORDER** often is not unique, so we can't just use it exlusively. We need something wider than that.
+Since the **ORDER** field often is not unique, we can't use it exclusively. We need something more reliable than that.
 
 So let's build the pagination of news feed. We'll use item created date as an **ORDER**.
 
-The table **news** will look the next way.
+The table **news** will look as follows.
 ```
  uid | title           | content                       | datetime
 --------------------------------------------------------------------
@@ -44,15 +44,15 @@ The table **news** will look the next way.
 
 Since *datetime* is not unique, but *ID* is, we need to create a single directional list of items using it.
 
-The database index will help to chain items by those files.
+The database index will help to chain items by those fields.
 {% gist 5b4936232c1d8cae5f3c39f57376df2a %}
 
 Now query to get the next page will be:
 {% gist 22652f6ed9e4b05b009bc63d35d101a2 %}
 
-Links to previous & next pages could be provided by API as a part of response, but also the application which uses API could build it on its own according the latest response.
+Links to previous and next pages could be provided by the API as part of the response, but the application using the API could also build them on its own according to the latest response.
 
-Getting previous page a little bit different:
+Getting the previous page is a little bit different:
 {% gist 7f075577b3bb06524f7bdcc5409771b0 %}
 
-So we change the order, but then reverse items before sending it as a response.
+So we change the order but then reverse the items before sending them as a response.


### PR DESCRIPTION
## Summary
- fix grammar and typos in early WordPress deployment post
- improve language in DigitalOcean Terraform article
- fix grammar in Facebook HTTPS rant
- clean up Terraform module example instructions
- correct git ignore post wording
- update WordPress security cheat sheet text
- refine cursor-based pagination article

## Testing
- `npm test` *(fails: Missing script)*
- `bundle exec jekyll build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6863bd186910832996eab28dd820ff44